### PR TITLE
fix: native-image 에서 TileInfo 가 빈 값으로 나오는 현상 수정

### DIFF
--- a/core/src/main/kotlin/dev/tronto/titiler/tile/domain/TileInfo.kt
+++ b/core/src/main/kotlin/dev/tronto/titiler/tile/domain/TileInfo.kt
@@ -1,7 +1,9 @@
 package dev.tronto.titiler.tile.domain
 
 import dev.tronto.titiler.core.domain.Info
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class TileInfo(
     val minZoom: Int,
     val maxZoom: Int,


### PR DESCRIPTION
resolve #49