### PR TITLE
refactor: GdalRenderer 리팩토링

### DIFF
--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalJpegRenderer.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalJpegRenderer.kt
@@ -32,15 +32,21 @@ class NDArrayGdalJpegRenderer : ImageRenderer {
             require(imageData is NDArrayImageData<*>)
             val data = imageData.data as D3Array<Int>
             val mask = imageData.mask
-            return GdalRenderer("JPEG", imageData.width, imageData.height, imageData.band, imageData.dataType).use {
-                val d3 = when (imageData.band) {
-                    1 -> mask.expandDims(0)
-                    3 -> mk.stack(mask, mask, mask)
-                    else -> throw IllegalStateException("Unsupported mask band: ${imageData.band}")
-                }
-                val dataArray = data.times(d3).toIntArray()
-                it.write(dataArray, IntArray(imageData.band) { it + 1 })
-                it.toByteArray()
+            val d3 = when (imageData.band) {
+                1 -> mask.expandDims(0)
+                3 -> mk.stack(mask, mask, mask)
+                else -> throw IllegalStateException("Unsupported mask band: ${imageData.band}")
+            }
+            val dataArray = data.times(d3).toIntArray()
+            return render(
+                "JPEG",
+                imageData.width,
+                imageData.height,
+                imageData.band,
+                imageData.dataType,
+                "image"
+            ) {
+                write(dataArray, IntArray(imageData.band) { it + 1 })
             }
         }
 }

--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalPngRenderer.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalPngRenderer.kt
@@ -35,16 +35,23 @@ class NDArrayGdalPngRenderer : ImageRenderer {
             require(imageData is NDArrayImageData<*>)
             val data = imageData.data as D3Array<Int>
             val mask = imageData.mask
-            return GdalRenderer("PNG", imageData.width, imageData.height, imageData.band, imageData.dataType).use {
-                val d3 = when (imageData.band) {
-                    1 -> mask.expandDims(0)
-                    3 -> mk.stack(mask, mask, mask)
-                    4 -> mk.stack(mask, mask, mask, mask)
-                    else -> throw IllegalStateException("Unsupported mask band: ${imageData.band}")
-                }
-                val dataArray = data.times(d3).toIntArray()
-                it.write(dataArray, IntArray(imageData.band) { it + 1 })
-                it.toByteArray()
+
+            val d3 = when (imageData.band) {
+                1 -> mask.expandDims(0)
+                3 -> mk.stack(mask, mask, mask)
+                4 -> mk.stack(mask, mask, mask, mask)
+                else -> throw IllegalStateException("Unsupported mask band: ${imageData.band}")
+            }
+            val dataArray = data.times(d3).toIntArray()
+            return render(
+                "PNG",
+                imageData.width,
+                imageData.height,
+                imageData.band,
+                imageData.dataType,
+                "image"
+            ) {
+                write(dataArray, IntArray(imageData.band) { it + 1 })
             }
         }
 }


### PR DESCRIPTION
UUID 생성을 제거하고 대신 이름이 겹칠 것을 대비해 하나의 쓰레드에서 GdalRenderer 작업하는 것을 보장하는 함수 추가