### PR TITLE
101 segFault 에러 발생

### DIFF
--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/outgoing/adaptor/gdal/GdalDataset.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/outgoing/adaptor/gdal/GdalDataset.kt
@@ -1,6 +1,7 @@
 package dev.tronto.kitiler.core.outgoing.adaptor.gdal
 
 import dev.tronto.kitiler.core.domain.DataType
+import dev.tronto.kitiler.core.outgoing.adaptor.gdal.get
 import dev.tronto.kitiler.core.outgoing.adaptor.jts.AffineCoordinateTransform
 import dev.tronto.kitiler.core.outgoing.port.CRS
 import dev.tronto.kitiler.core.outgoing.port.CRSFactory
@@ -36,10 +37,7 @@ class GdalDataset(val name: String, val dataset: Dataset, private val memFilePat
     }
 
     override fun close() {
-        kotlin.runCatching {
-            sampleBand.delete()
-        }
-        kotlin.runCatching {
+        runCatching {
             dataset.delete()
         }
         memFilePath?.let { gdal.Unlink(it) }

--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/outgoing/adaptor/gdal/GdalEx.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/outgoing/adaptor/gdal/GdalEx.kt
@@ -18,6 +18,7 @@ import dev.tronto.kitiler.core.domain.DataType.UInt64
 import dev.tronto.kitiler.core.domain.DataType.UInt8
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.gdal.gdal.MajorObject
+import org.gdal.gdal.WarpOptions
 import org.gdal.gdal.gdal
 import org.gdal.gdalconst.gdalconst
 
@@ -28,6 +29,17 @@ internal object GdalEx {
 
     @JvmStatic
     val errorCodes = listOf(gdalconst.CE_Failure, gdalconst.CE_Fatal)
+}
+
+inline fun <T> WarpOptions.use(block: (WarpOptions) -> T): T = try {
+    block(this)
+} finally {
+    try {
+        this.delete()
+    } catch (e: RuntimeException) {
+        // ignore
+        GdalEx.logger.warn(e) { "Failed to delete ${this::class.simpleName}." }
+    }
 }
 
 inline fun <O : MajorObject, T> O.use(block: (O) -> T): T = try {

--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/outgoing/adaptor/gdal/GdalRasterFactory.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/outgoing/adaptor/gdal/GdalRasterFactory.kt
@@ -21,20 +21,19 @@ open class GdalRasterFactory(
 
     private fun createGdalRaster(gdalDataset: GdalDataset, vararg options: OptionProvider<*>): GdalRaster {
         val dataset = gdalDataset.dataset
-        val bandInfos = (1..gdalDataset.bandCount).map { band ->
-            dataset.GetRasterBand(band).use {
-                BandInfo(
-                    BandIndex(band),
-                    DataType[it.dataType],
-                    it.GetDescription() ?: "",
-                    ColorInterpretation[it.GetColorInterpretation()],
-                    it.GetMetadata_Dict().mapNotNull {
-                        val key = it.key as? String ?: return@mapNotNull null
-                        val value = it.value as? String ?: return@mapNotNull null
-                        key to value
-                    }.toMap()
-                )
-            }
+        val bandInfos = (1..gdalDataset.bandCount).map { bandIndex ->
+            val band = dataset.GetRasterBand(bandIndex)
+            BandInfo(
+                BandIndex(bandIndex),
+                DataType[band.dataType],
+                band.GetDescription() ?: "",
+                ColorInterpretation[band.GetColorInterpretation()],
+                band.GetMetadata_Dict().mapNotNull {
+                    val key = it.key as? String ?: return@mapNotNull null
+                    val value = it.value as? String ?: return@mapNotNull null
+                    key to value
+                }.toMap()
+            )
         }
 
         val crs = gdalDataset.getCrs(crsFactory)
@@ -44,7 +43,7 @@ open class GdalRasterFactory(
             gdalDataset.width,
             gdalDataset.height,
             gdalDataset.bandCount,
-            dataset.GetDriver().use { it.shortName },
+            dataset.GetDriver().shortName,
             gdalDataset.dataType,
             gdalDataset.pixelCoordinateTransform,
             gdalDataset.noDataValue,

--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/utils/GdalInit.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/core/utils/GdalInit.kt
@@ -1,0 +1,14 @@
+package dev.tronto.kitiler.core.utils
+
+import org.gdal.gdal.gdal
+import org.gdal.ogr.ogr
+import org.gdal.osr.osr
+
+object GdalInit {
+    init {
+        gdal.AllRegister()
+        gdal.UseExceptions()
+        ogr.UseExceptions()
+        osr.UseExceptions()
+    }
+}

--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/GdalRenderer.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/GdalRenderer.kt
@@ -2,38 +2,45 @@ package dev.tronto.kitiler.image.outgoing.adaptor.gdal
 
 import dev.tronto.kitiler.core.domain.DataType
 import dev.tronto.kitiler.core.outgoing.adaptor.gdal.gdalConst
+import dev.tronto.kitiler.core.outgoing.adaptor.gdal.handleError
 import dev.tronto.kitiler.core.outgoing.adaptor.gdal.use
+import dev.tronto.kitiler.core.utils.GdalInit
 import dev.tronto.kitiler.core.utils.logTrace
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.gdal.gdal.Dataset
 import org.gdal.gdal.Driver
 import org.gdal.gdal.gdal
+import java.util.*
 
-class GdalRenderer(
+class GdalRenderer private constructor(
     driverName: String,
     private val width: Int,
     private val height: Int,
     private val band: Int,
     type: DataType,
     name: String,
-) : AutoCloseable {
-    companion object {
-        private val logger = KotlinLogging.logger { }
-    }
-
-    private val driver: Driver = gdal.GetDriverByName(driverName)
-    private val path: String = "/vsimem/$name"
-    private val dataset: Dataset
-    private val buffered: Boolean
+) {
 
     init {
-        if (driver.canCreateCopy) {
-            dataset = gdal.GetDriverByName("Mem")
-                .Create(path, width, height, band, type.gdalConst)
-            buffered = true
-        } else if (driver.canCreate) {
+        GdalInit
+    }
+
+    /**
+     *  /vsimem 은 같은 경로에 대해 하나의 프로세스에서(모든 쓰레드에서) 접근할 수 있기에 UUID 로 경로를 구분함.
+     */
+    private val path: String = "/vsimem/${UUID.randomUUID()}/$name"
+
+    private val dataset: Dataset
+    private val buffered: Boolean
+    private val driver: Driver = gdal.GetDriverByName(driverName)
+
+    init {
+        if (driver.canCreate) {
             dataset = driver.Create(path, width, height, band, type.gdalConst)
             buffered = false
+        } else if (driver.canCreateCopy) {
+            dataset = memDriver.Create(path, width, height, band, type.gdalConst)
+            buffered = true
         } else {
             throw IllegalArgumentException("driver $driverName cannot create dataset.")
         }
@@ -41,14 +48,17 @@ class GdalRenderer(
 
     fun write(data: IntArray, bands: IntArray) = logger.logTrace("GdalRenderer.write()") {
         require(bands.all { it in 1..band })
-        dataset.WriteRaster(0, 0, width, height, width, height, DataType.Int32.gdalConst, data, bands)
+        dataset.handleError {
+            WriteRaster(0, 0, width, height, width, height, DataType.Int32.gdalConst, data, bands)
+        }
     }
 
-    fun toByteArray(): ByteArray = logger.logTrace("GdalRenderer.toByteArray()") {
+    fun flush(): ByteArray = logger.logTrace("GdalRenderer.flush()") {
         dataset.FlushCache()
-        return if (buffered) {
+        val result = if (buffered) {
             val tmpPath = "$path.tmp"
             driver.CreateCopy(tmpPath, dataset).use {
+                it.FlushCache()
                 gdal.GetMemFileBuffer(tmpPath)
             }.also {
                 gdal.Unlink(tmpPath)
@@ -56,35 +66,38 @@ class GdalRenderer(
         } else {
             gdal.GetMemFileBuffer(path)
         }
-    }
-
-    override fun close() {
         dataset.delete()
         gdal.Unlink(path)
+        return result
     }
-}
 
-/**
- *
- *  하나의 쓰레드에서 작업하는 것을 보장하기 위한 함수. [name] 이 같을 경우에 유용하게 사용할 수 있음.
- *  /vsimem 의 데이터셋 이름은 쓰레드별로 구분되기 때문에 쓰레드 구분이 필요
- */
-fun render(
-    driverName: String,
-    width: Int,
-    height: Int,
-    band: Int,
-    type: DataType,
-    name: String,
-    block: GdalRenderer.() -> Unit,
-): ByteArray = GdalRenderer(
-    driverName,
-    width,
-    height,
-    band,
-    type,
-    name
-).use {
-    it.block()
-    it.toByteArray()
+    companion object {
+        private val logger = KotlinLogging.logger { }
+        private val memDriver by lazy {
+            gdal.GetDriverByName("Mem")!!
+        }
+
+        /**
+         *  하나의 쓰레드에서 작업하는 것을 보장하기 위해 사용.
+         */
+        fun render(
+            driverName: String,
+            width: Int,
+            height: Int,
+            band: Int,
+            type: DataType,
+            name: String,
+            block: GdalRenderer.() -> Unit,
+        ): ByteArray = GdalRenderer(
+            driverName,
+            width,
+            height,
+            band,
+            type,
+            name
+        ).let {
+            it.block()
+            it.flush()
+        }
+    }
 }

--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalJpegRenderer.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalJpegRenderer.kt
@@ -38,13 +38,13 @@ class NDArrayGdalJpegRenderer : ImageRenderer {
                 else -> throw IllegalStateException("Unsupported mask band: ${imageData.band}")
             }
             val dataArray = data.times(d3).toIntArray()
-            return render(
+            return GdalRenderer.render(
                 "JPEG",
                 imageData.width,
                 imageData.height,
                 imageData.band,
                 imageData.dataType,
-                "image"
+                "image.jpeg"
             ) {
                 write(dataArray, IntArray(imageData.band) { it + 1 })
             }

--- a/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalPngRenderer.kt
+++ b/kitiler-core/src/main/kotlin/dev/tronto/kitiler/image/outgoing/adaptor/gdal/NDArrayGdalPngRenderer.kt
@@ -43,13 +43,13 @@ class NDArrayGdalPngRenderer : ImageRenderer {
                 else -> throw IllegalStateException("Unsupported mask band: ${imageData.band}")
             }
             val dataArray = data.times(d3).toIntArray()
-            return render(
+            return GdalRenderer.render(
                 "PNG",
                 imageData.width,
                 imageData.height,
                 imageData.band,
                 imageData.dataType,
-                "image"
+                "image.png"
             ) {
                 write(dataArray, IntArray(imageData.band) { it + 1 })
             }


### PR DESCRIPTION
## 작업 내용

1. segfault 원인 파악 후 수정
2. gdal 객체에 대해 필요한 경우에만 delete() 호출 - delete 를 더 적게 사용하여 성능이 매우 약간 향상될 것
3. 일부 코드를 다듬음

## 에러 원인
gdal 에서 제공하는 /vsimem 은 경로가 같으면 모든 쓰레드에서 하나의 데이터셋에 접근함.
같은 경로의 이미지에 접근하여 Write 후에 Unlink 를 해버리기 때문에, 쓰기 작업중에 해당 데이터셋이 삭제되고, 쓰기 작업 중인 메모리 주소가 유효하지 않은 위치가 되어버림.

따라서 `UUID.randomUUID()` 를 사용하여 매번 새로운 경로를 사용하도록 만들어서 수정함.

resolve #101