### PR TITLE
chore: arm64 에서도 그대로 빌드될 수 있도록 수정

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,11 +1,16 @@
-name: release
+name: pre-release
 on:
   push:
     branches:
       - develop
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  publish-spring:
+  publish-spring-amd:
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -31,10 +36,72 @@ jobs:
             -Pimage.registry.publish.username=${{github.actor}} \
             -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-${{ github.ref_name }}-${{ github.run_id }} \
+            -Pimage.tags=spring-${{ github.ref_name }}-amd \
             -Pimage.push=true
 
-  publish-spring-native:
+  publish-spring-arm:
+    runs-on: ubuntu-24.04-arm
+    environment: release
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - uses: gradle/actions/setup-gradle@v3
+        name: setup gradle
+
+      - name: build and publish Container Image with gradle
+        run: |
+          ./gradlew :kitiler-spring-application:buildImage \
+            --parallel \
+            --continue \
+            -Pimage.native.enabled=false \
+            -Pimage.registry.publish.username=${{github.actor}} \
+            -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
+            -Pimage.name=ghcr.io/tronto20/kitiler \
+            -Pimage.tags=spring-${{ github.ref_name }}-arm,spring-${{ github.ref_name }}-${{ github.run_id }}-arm \
+            -Pimage.push=true
+
+  publish-spring-manifest:
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+
+    needs:
+      - publish-spring-amd
+      - publish-spring-arm
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest
+        id: build multi-arch image
+        run: |
+          docker buildx imagetools create \
+          -t spring-${{ github.ref_name }} \
+          -t spring-${{ github.ref_name }}-${{ github.run_id }} \
+          spring-${{ github.ref_name }}-${{ github.run_id }}-amd \
+          spring-${{ github.ref_name }}-${{ github.run_id }}-arm
+
+
+  publish-spring-native-amd:
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -59,5 +126,67 @@ jobs:
             -Pimage.registry.publish.username=${{github.actor}} \
             -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-${{ github.ref_name }}-${{ github.run_id }} \
+            -Pimage.tags=spring-native-${{ github.ref_name }}-${{ github.run_id }}-amd,spring-native-${{ github.ref_name }}-amd,${{ github.ref_name }}-${{ github.run_id }}-amd,${{ github.ref_name }}-amd \
             -Pimage.push=true
+
+  publish-spring-native-arm:
+    runs-on: ubuntu-24.04-arm
+    environment: release
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - uses: gradle/actions/setup-gradle@v3
+        name: setup gradle
+
+      - name: build and publish Container Image with gradle
+        run: |
+          ./gradlew :kitiler-spring-application:buildImage \
+            --parallel \
+            --continue \
+            -Pimage.registry.publish.username=${{github.actor}} \
+            -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
+            -Pimage.name=ghcr.io/tronto20/kitiler \
+            -Pimage.tags=spring-native-${{ github.ref_name }}-${{ github.run_id }}-arm,spring-native-${{ github.ref_name }}-arm,${{ github.ref_name }}-${{ github.run_id }}-arm,${{ github.ref_name }}-amd \
+            -Pimage.push=true
+
+  publish-spring-native-manifest:
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+
+    needs:
+      - publish-spring-native-amd
+      - publish-spring-native-arm
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest
+        id: build multi-arch image
+        run: |
+          docker buildx imagetools create \
+          -t ${{ github.ref_name }} \
+          -t ${{ github.ref_name }}-${{ github.run_id }} \
+          -t spring-native-${{ github.ref_name }} \
+          -t spring-native-${{ github.ref_name }}-${{ github.run_id }} \
+          spring-native-${{ github.ref_name }}-${{ github.run_id }}-amd \
+          spring-native-${{ github.ref_name }}-${{ github.run_id }}-arm

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,4 +1,4 @@
-name: pre-release
+name: release-on-develop
 on:
   push:
     branches:

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-spring:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
     permissions:
       packages: write
@@ -35,7 +35,7 @@ jobs:
             -Pimage.push=true
 
   publish-spring-native:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
     permissions:
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,7 @@
 name: release
 on:
-  push:
-    tags:
-      - [0-9].[0-9].[0-9]
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-maven:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
     steps:
       - uses: actions/checkout@v4
@@ -29,9 +29,37 @@ jobs:
             -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }} \
             -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_KEY_PASSWORD }}
 
-
   publish-spring:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - uses: gradle/actions/setup-gradle@v3
+        name: setup gradle
+
+      - name: build and publish Container Image with gradle
+        run: |
+          ./gradlew :kitiler-spring-application:buildImage \
+            --parallel \
+            --continue \
+            -Pimage.native.enabled=false \
+            -Pimage.registry.publish.username=${{github.actor}} \
+            -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
+            -Pimage.name=ghcr.io/tronto20/kitiler \
+            -Pimage.tags=spring-latest,spring-{VERSION} \
+            -Pimage.push=true
+
+  publish-spring-arm:
+    runs-on: ubuntu-24.04-arm
     environment: release
     permissions:
       packages: write
@@ -60,7 +88,35 @@ jobs:
             -Pimage.push=true
 
   publish-spring-native:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - uses: gradle/actions/setup-gradle@v3
+        name: setup gradle
+
+      - name: build and publish Container Image with gradle
+        run: |
+          ./gradlew :kitiler-spring-application:buildImage \
+            --parallel \
+            --continue \
+            -Pimage.registry.publish.username=${{github.actor}} \
+            -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
+            -Pimage.name=ghcr.io/tronto20/kitiler \
+            -Pimage.tags=spring-native-latest,spring-native-{VERSION},latest,{VERSION} \
+            -Pimage.push=true
+
+  publish-spring-native-arm:
+    runs-on: ubuntu-24.04-arm
     environment: release
     permissions:
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,12 @@
 name: release
 on:
   push:
-    branches:
-      - main
+    tags:
+      - [0-9].[0-9].[0-9]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish-maven:
@@ -27,9 +31,10 @@ jobs:
             -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
             -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
             -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }} \
-            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_KEY_PASSWORD }}
+            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_KEY_PASSWORD }} \
+            -Pversion=${{ github.ref_name }}
 
-  publish-spring:
+  publish-spring-amd:
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -55,8 +60,9 @@ jobs:
             -Pimage.registry.publish.username=${{github.actor}} \
             -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-latest,spring-{VERSION} \
-            -Pimage.push=true
+            -Pimage.tags=spring-latest-amd,spring-${{ github.ref_name }}-amd \
+            -Pimage.push=true \
+            -Pversion=${{ github.ref_name }}
 
   publish-spring-arm:
     runs-on: ubuntu-24.04-arm
@@ -84,10 +90,45 @@ jobs:
             -Pimage.registry.publish.username=${{github.actor}} \
             -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-latest,spring-{VERSION} \
-            -Pimage.push=true
+            -Pimage.tags=spring-latest-arm,spring-${{ github.ref_name }}-arm \
+            -Pimage.push=true \
+            -Pversion=${{ github.ref_name }}
 
-  publish-spring-native:
+  publish-spring-manifest:
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+
+    needs:
+      - publish-spring-amd
+      - publish-spring-arm
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest
+        id: build multi-arch image
+        run: |
+          docker buildx imagetools create \
+          -t spring \
+          -t spring-latest \
+          -t spring-${{ github.ref_name }} \
+          spring-${{ github.ref_name }}-amd \
+          spring-${{ github.ref_name }}-arm
+
+
+  publish-spring-native-amd:
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -112,8 +153,9 @@ jobs:
             -Pimage.registry.publish.username=${{github.actor}} \
             -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-native-latest,spring-native-{VERSION},latest,{VERSION} \
-            -Pimage.push=true
+            -Pimage.tags=spring-native-latest-amd,spring-native-${{ github.ref_name }}-amd,latest-amd,${{ github.ref_name }}-amd \
+            -Pimage.push=true \
+            -Pversion=${{ github.ref_name }}
 
   publish-spring-native-arm:
     runs-on: ubuntu-24.04-arm
@@ -140,5 +182,41 @@ jobs:
             -Pimage.registry.publish.username=${{github.actor}} \
             -Pimage.registry.publish.password=${{secrets.GITHUB_TOKEN}} \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-native-latest,spring-native-{VERSION},latest,{VERSION} \
-            -Pimage.push=true
+            -Pimage.tags=spring-native-latest-arm,spring-native-${{ github.ref_name }}-arm,latest-arm,${{ github.ref_name }}-arm \
+            -Pimage.push=true \
+            -Pversion=${{ github.ref_name }}
+
+  publish-spring-native-manifest:
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+
+    needs:
+      - publish-spring-native-amd
+      - publish-spring-native-arm
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest
+        id: build multi-arch image
+        run: |
+          docker buildx imagetools create \
+          -t latest \
+          -t ${{ github.ref_name }} \
+          -t spring-native \
+          -t spring-native-latest \
+          -t spring-native-${{ github.ref_name }} \
+          spring-native-${{ github.ref_name }}-amd \
+          spring-native-${{ github.ref_name }}-arm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   gradle-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,8 +24,8 @@ jobs:
       - run: ./gradlew build --parallel --continue
 
 
-  publish-spring:
-    runs-on: ubuntu-latest
+  test-publish-spring:
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -47,8 +47,53 @@ jobs:
             -Pimage.tags=spring-latest,spring-{VERSION} \
             -Pimage.push=false
 
-  publish-spring-native:
-    runs-on: ubuntu-latest
+  test-publish-spring-arm:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - uses: gradle/actions/setup-gradle@v3
+        name: setup gradle
+
+      - name: build and publish Container Image with gradle
+        run: |
+          ./gradlew :kitiler-spring-application:buildImage \
+            --parallel \
+            --continue \
+            -Pimage.native.enabled=false \
+            -Pimage.name=ghcr.io/tronto20/kitiler \
+            -Pimage.tags=spring-latest,spring-{VERSION} \
+            -Pimage.push=false
+
+  test-publish-spring-native:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - uses: gradle/actions/setup-gradle@v3
+        name: setup gradle
+
+      - name: build and publish Container Image with gradle
+        run: |
+          ./gradlew :kitiler-spring-application:buildImage \
+            --parallel \
+            --continue \
+            -Pimage.name=ghcr.io/tronto20/kitiler \
+            -Pimage.tags=spring-native-latest,spring-native-{VERSION},latest,{VERSION} \
+            -Pimage.push=false
+
+  test-publish-spring-native-arm:
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -59,6 +59,8 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v3
         name: setup gradle
+        with:
+          cache-disabled: true
 
       - name: build and publish Container Image with gradle
         run: |
@@ -104,6 +106,8 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v3
         name: setup gradle
+        with:
+          cache-disabled: true
 
       - name: build and publish Container Image with gradle
         run: |

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -44,7 +44,7 @@ jobs:
             --continue \
             -Pimage.native.enabled=false \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-${{ github.ref_name }}-${{ github.run_id }}-amd \
+            -Pimage.tags=spring-${{ github.base_ref }}-${{ github.run_id }}-amd \
             -Pimage.push=false
 
   test-publish-spring-arm:

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -69,7 +69,7 @@ jobs:
             --continue \
             -Pimage.native.enabled=false \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-${{ github.ref_name }}-${{ github.run_id }}-arm \
+            -Pimage.tags=spring-${{ github.base_ref }}-${{ github.run_id }}-arm \
             -Pimage.push=false
 
   test-publish-spring-native:
@@ -91,7 +91,7 @@ jobs:
             --parallel \
             --continue \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-native-${{ github.ref_name }}-${{ github.run_id }}-amd \
+            -Pimage.tags=spring-native-${{ github.base_ref }}-${{ github.run_id }}-amd \
             -Pimage.push=false
 
   test-publish-spring-native-arm:
@@ -115,5 +115,5 @@ jobs:
             --parallel \
             --continue \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-native-${{ github.ref_name }}-${{ github.run_id }}-arm \
+            -Pimage.tags=spring-native-${{ github.base_ref }}-${{ github.run_id }}-arm \
             -Pimage.push=false

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -44,7 +44,7 @@ jobs:
             --continue \
             -Pimage.native.enabled=false \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-latest,spring-{VERSION} \
+            -Pimage.tags=spring-${{ github.ref_name }}-${{ github.run_id }}-amd \
             -Pimage.push=false
 
   test-publish-spring-arm:
@@ -69,7 +69,7 @@ jobs:
             --continue \
             -Pimage.native.enabled=false \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-latest,spring-{VERSION} \
+            -Pimage.tags=spring-${{ github.ref_name }}-${{ github.run_id }}-arm \
             -Pimage.push=false
 
   test-publish-spring-native:
@@ -91,7 +91,7 @@ jobs:
             --parallel \
             --continue \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-native-latest,spring-native-{VERSION},latest,{VERSION} \
+            -Pimage.tags=spring-native-${{ github.ref_name }}-${{ github.run_id }}-amd \
             -Pimage.push=false
 
   test-publish-spring-native-arm:
@@ -115,5 +115,5 @@ jobs:
             --parallel \
             --continue \
             -Pimage.name=ghcr.io/tronto20/kitiler \
-            -Pimage.tags=spring-native-latest,spring-native-{VERSION},latest,{VERSION} \
+            -Pimage.tags=spring-native-${{ github.ref_name }}-${{ github.run_id }}-arm \
             -Pimage.push=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ jvm.version=17
 version=0.4.0-SNAPSHOT
 # build-image
 image.native.enabled=true
-image.native.compression=upx
+image.native.compression=none
 image.name=ghcr.io/tronto20/kitiler
 publish.maven-central.plugin.version=0.30.0
 # maven-central

--- a/kitiler-spring-application/Dockerfile
+++ b/kitiler-spring-application/Dockerfile
@@ -6,5 +6,5 @@ ARG JNI=/usr/lib/x86_64-linux-gnu/jni
 ENV LD_LIBRARY_PATH $JNI
 ENV GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR
 
-ARG STACK_ID=io.buildpacks.stacks.jammy.tiny
+ARG STACK_ID=io.buildpacks.stacks.noble.tiny
 LABEL io.buildpacks.stack.id=$STACK_ID

--- a/kitiler-spring-application/build.gradle.kts
+++ b/kitiler-spring-application/build.gradle.kts
@@ -139,7 +139,7 @@ if (DefaultNativePlatform.getCurrentArchitecture().isArm64) {
     }
 
     tasks.bootBuildImage {
-        builder.set("paketobuildpacks/builder-jammy-base:latest")
+        builder.set("paketobuildpacks/builder-jammy-full:latest")
     }
 }
 

--- a/kitiler-spring-application/build.gradle.kts
+++ b/kitiler-spring-application/build.gradle.kts
@@ -131,6 +131,18 @@ tasks.bootBuildImage {
     environment.set(envs)
 }
 
+
+if (DefaultNativePlatform.getCurrentArchitecture().isArm64) {
+    buildRunnerImageTask {
+        args("--build-arg")
+        args("STACK_ID=io.buildpacks.stacks.jammy")
+    }
+
+    tasks.bootBuildImage {
+        builder.set("paketobuildpacks/builder-jammy-base:latest")
+    }
+}
+
 tasks.register("buildImage") {
     group = "build"
     dependsOn(tasks.bootBuildImage)

--- a/kitiler-spring-application/build.gradle.kts
+++ b/kitiler-spring-application/build.gradle.kts
@@ -72,6 +72,9 @@ val buildRunnerImageTask = tasks.register("buildRunnerImage", PathExec::class.ja
     val gdalVersion = libs.versions.gdal.get()
     args("--build-arg")
     args("GDAL_VERSION=${gdalVersion}")
+    args("--build-arg")
+    args("STACK_ID=io.buildpacks.stacks.noble.tiny")
+
     if (DefaultNativePlatform.getCurrentArchitecture().isArm64) {
         args("--build-arg")
         args("JNI=/usr/lib/aarch64-linux-gnu/jni")
@@ -129,18 +132,7 @@ tasks.bootBuildImage {
     envs["BP_JVM_VERSION"] = jvmVersion.toString()
     envs["BPE_DELIM_JAVA_TOOL_OPTIONS"] = " "
     environment.set(envs)
-}
-
-
-if (DefaultNativePlatform.getCurrentArchitecture().isArm64) {
-    buildRunnerImageTask {
-        args("--build-arg")
-        args("STACK_ID=io.buildpacks.stacks.jammy")
-    }
-
-    tasks.bootBuildImage {
-        builder.set("paketobuildpacks/builder-jammy-full:latest")
-    }
+    builder.set("paketobuildpacks/builder-noble-java-tiny:latest")
 }
 
 tasks.register("buildImage") {


### PR DESCRIPTION
resolve #83

upx 를 포기하고 `paketobuildpack/builder-noble-java-tiny` builder 를 선택.

기본 빌더 : paketobuildpack/builder-jammy-java-tiny
- linux/amd64 만 지원. linux/amd64 를 지원하는 경우 가능.
- 그러나 arm64 기기에서는 upx 가 동작하지 않음.

이전 버전의 기본 빌더 : paketobuildpack/builder-jammy-base
- linux/amd64 만 지원. linux/amd64 를 지원하는 경우 가능.
- arm64 기기에서도 upx 가 동작함.

선택한 빌더 : paketobuildpack/builder-noble-java-tiny
- linux/amd64, linux/arm64 모두 지원
- arm64 기기에서는 upx 가 동작하지 않음.

upx 는 있으면 좋은 정도의 옵션이기 때문에 noble 을 선택.
linux/arm64 를 지원하는 paketobuildpack 이미지가 아직 많지 않았고, 빠르게 적용할 수 있는 java-tiny 를 선택함.
(이외에는 모두 buildpackless 였음)

---
2개의 아키텍처별 이미지 태그를 하나의 멀티 아키텍쳐 이미지로 합칠 수 있도록 추가했으나, 실제로 잘 작동하는지 확인 필요.